### PR TITLE
feat: getRelevantPairs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@reservoir-labs/sdk",
-  "version": "3.0.1",
+  "version": "0.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@reservoir-labs/sdk",
-      "version": "3.0.1",
+      "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
         "@ethersproject/address": "^5.0.0",
@@ -16,7 +16,7 @@
         "@ethersproject/providers": "^5.7.2",
         "@ethersproject/solidity": "^5.0.0",
         "@ethersproject/wallet": "^5.7.0",
-        "@reservoir-labs/sdk-core": "^3.1.1",
+        "@reservoir-labs/sdk-core": "^3.1.2",
         "decimal.js": "^10.4.3",
         "tiny-invariant": "^1.1.0",
         "tiny-warning": "^1.0.3"
@@ -3486,9 +3486,9 @@
       }
     },
     "node_modules/@reservoir-labs/sdk-core": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@reservoir-labs/sdk-core/-/sdk-core-3.1.1.tgz",
-      "integrity": "sha512-NVQUg7tmblL+Zou/a4NGK8E4rXHIee6t2KS4ZUXBQMzAoCmJA3uMXg8bd2yh75s5A6TjkHeTi5KP4+no/scROw==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@reservoir-labs/sdk-core/-/sdk-core-3.1.2.tgz",
+      "integrity": "sha512-91QX6Bt5vuQArapDy1TDcgi5VCI+5I+90ud9YAg2ltYkBfxe0AqhS4HnlGguyelszKDMmK5aHUbmrANyhuAR0Q==",
       "dependencies": {
         "@ethersproject/address": "^5.0.2",
         "big.js": "^5.2.2",
@@ -17894,9 +17894,9 @@
       }
     },
     "@reservoir-labs/sdk-core": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@reservoir-labs/sdk-core/-/sdk-core-3.1.1.tgz",
-      "integrity": "sha512-NVQUg7tmblL+Zou/a4NGK8E4rXHIee6t2KS4ZUXBQMzAoCmJA3uMXg8bd2yh75s5A6TjkHeTi5KP4+no/scROw==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@reservoir-labs/sdk-core/-/sdk-core-3.1.2.tgz",
+      "integrity": "sha512-91QX6Bt5vuQArapDy1TDcgi5VCI+5I+90ud9YAg2ltYkBfxe0AqhS4HnlGguyelszKDMmK5aHUbmrANyhuAR0Q==",
       "requires": {
         "@ethersproject/address": "^5.0.2",
         "big.js": "^5.2.2",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@ethersproject/providers": "^5.7.2",
     "@ethersproject/solidity": "^5.0.0",
     "@ethersproject/wallet": "^5.7.0",
-    "@reservoir-labs/sdk-core": "^3.1.1",
+    "@reservoir-labs/sdk-core": "^3.1.2",
     "decimal.js": "^10.4.3",
     "tiny-invariant": "^1.1.0",
     "tiny-warning": "^1.0.3"

--- a/src/entities/pair.ts
+++ b/src/entities/pair.ts
@@ -98,6 +98,7 @@ export class Pair {
   /**
    * Returns the current mid price of the pair in terms of token0, i.e. the ratio of reserve1 to reserve0
    */
+  // TODO: refactor this to take into account stable curve?
   public get token0Price(): Price<Token, Token> {
     const result = this.tokenAmounts[1].divide(this.tokenAmounts[0])
     return new Price(this.token0, this.token1, result.denominator, result.numerator)
@@ -106,6 +107,7 @@ export class Pair {
   /**
    * Returns the current mid price of the pair in terms of token1, i.e. the ratio of reserve0 to reserve1
    */
+  // TODO: refactor this to take into account stable curve?
   public get token1Price(): Price<Token, Token> {
     const result = this.tokenAmounts[0].divide(this.tokenAmounts[1])
     return new Price(this.token1, this.token0, result.denominator, result.numerator)
@@ -247,6 +249,7 @@ export class Pair {
     })
   }
 
+  // TODO: refactor this for stablePair calculations?
   public getLiquidityMinted(
     totalSupply: CurrencyAmount<Token>,
     tokenAmountA: CurrencyAmount<Token>,
@@ -275,6 +278,7 @@ export class Pair {
     return CurrencyAmount.fromRawAmount(this.liquidityToken, liquidity)
   }
 
+  // TODO: KIV, might need to refactor for the stablePair
   public getLiquidityValue(
     token: Token,
     totalSupply: CurrencyAmount<Token>,

--- a/src/fetcher.test.ts
+++ b/src/fetcher.test.ts
@@ -22,7 +22,6 @@ describe('fetcher', () => {
         new Token(43114, USDC_AVAX, 6),
         provider
       )
-
       expect(relevantPairs.length).toBeLessThan(6)
     })
   })

--- a/src/fetcher.test.ts
+++ b/src/fetcher.test.ts
@@ -2,13 +2,23 @@ import { Fetcher } from './fetcher'
 import { WETH9 as _WETH9 } from '@reservoir-labs/sdk-core/dist/entities/weth9'
 import { BaseProvider } from '@ethersproject/providers'
 import { WebSocketProvider } from '@ethersproject/providers'
+import {Token, WETH9} from "@reservoir-labs/sdk-core";
 
 describe('fetcher', () => {
   let provider: BaseProvider = new WebSocketProvider('ws://127.0.0.1:8545')
+  const USDC_AVAX = '0xB97EF9Ef8734C71904D8002F8b6Bc66Dd9c48a6E';
 
   it('should fetch pairs', async () => {
     const pairs = await Fetcher.fetchAllPairs(43114, provider)
 
     expect(pairs.length).toEqual(1)
+  })
+
+  describe('fetchRelevantPairs', () => {
+    it('should not return pairs that have not been created', async () => {
+      const relevantPairs = await Fetcher.fetchRelevantPairs(43114, WETH9[43114], new Token(43114, USDC_AVAX, 6), provider)
+
+      expect(relevantPairs.length).toBeLessThan(6)
+    })
   })
 })

--- a/src/fetcher.test.ts
+++ b/src/fetcher.test.ts
@@ -2,11 +2,11 @@ import { Fetcher } from './fetcher'
 import { WETH9 as _WETH9 } from '@reservoir-labs/sdk-core/dist/entities/weth9'
 import { BaseProvider } from '@ethersproject/providers'
 import { WebSocketProvider } from '@ethersproject/providers'
-import {Token, WETH9} from "@reservoir-labs/sdk-core";
+import { Token, WETH9 } from '@reservoir-labs/sdk-core'
 
 describe('fetcher', () => {
   let provider: BaseProvider = new WebSocketProvider('ws://127.0.0.1:8545')
-  const USDC_AVAX = '0xB97EF9Ef8734C71904D8002F8b6Bc66Dd9c48a6E';
+  const USDC_AVAX = '0xB97EF9Ef8734C71904D8002F8b6Bc66Dd9c48a6E'
 
   it('should fetch pairs', async () => {
     const pairs = await Fetcher.fetchAllPairs(43114, provider)
@@ -16,7 +16,12 @@ describe('fetcher', () => {
 
   describe('fetchRelevantPairs', () => {
     it('should not return pairs that have not been created', async () => {
-      const relevantPairs = await Fetcher.fetchRelevantPairs(43114, WETH9[43114], new Token(43114, USDC_AVAX, 6), provider)
+      const relevantPairs = await Fetcher.fetchRelevantPairs(
+        43114,
+        WETH9[43114],
+        new Token(43114, USDC_AVAX, 6),
+        provider
+      )
 
       expect(relevantPairs.length).toBeLessThan(6)
     })

--- a/src/fetcher.ts
+++ b/src/fetcher.ts
@@ -1,7 +1,7 @@
 import { Contract } from '@ethersproject/contracts'
 import { getNetwork } from '@ethersproject/networks'
 import { getDefaultProvider } from '@ethersproject/providers'
-import { SupportedChainId, Token, CurrencyAmount } from '@reservoir-labs/sdk-core'
+import {SupportedChainId, Token, CurrencyAmount, WETH9} from '@reservoir-labs/sdk-core'
 import { Pair } from './entities/pair'
 import invariant from 'tiny-invariant'
 import { FACTORY_ADDRESS } from './constants'
@@ -62,10 +62,10 @@ export abstract class Fetcher {
     const constantProduct = await factory.getPair(tokenA.address, tokenB.address, 0)
 
     // get native pairs
-    const nativeTokenAConstantProduct = await factory.getPair(tokenA.address, ??, 0)
-    const nativeTokenAStable = await factory.getPair(tokenA.address, ??, 1)
-    const nativeTokenBConstantProduct = await factory.getPair(tokenA.address, ??, 0)
-    const nativeTokenBStable = await factory.getPair(tokenA.address, ??, 1)
+    const nativeTokenAConstantProduct = await factory.getPair(tokenA.address, WETH9[chainId], 0)
+    const nativeTokenAStable = await factory.getPair(tokenA.address, WETH9[chainId], 1)
+    const nativeTokenBConstantProduct = await factory.getPair(tokenA.address, WETH9[chainId], 0)
+    const nativeTokenBStable = await factory.getPair(tokenA.address, WETH9[chainId], 1)
 
     return [stable, constantProduct, nativeTokenAConstantProduct, nativeTokenAStable, nativeTokenBConstantProduct, nativeTokenBStable].filter(address => address != null)
   }

--- a/src/fetcher.ts
+++ b/src/fetcher.ts
@@ -77,7 +77,7 @@ export abstract class Fetcher {
       nativeTokenBStable
     ].filter(address => address != AddressZero)
 
-    return [... new Set(relevantPairs)] // de-duplicate repeated addresses
+    return [...new Set(relevantPairs)] // de-duplicate repeated addresses
   }
 
   /**

--- a/src/fetcher.ts
+++ b/src/fetcher.ts
@@ -8,6 +8,7 @@ import { FACTORY_ADDRESS } from './constants'
 import GenericFactory from './abis/GenericFactory.json'
 import ReservoirPair from './abis/ReservoirPair.json'
 import JSBI from 'jsbi'
+import {AddressZero} from "@ethersproject/constants";
 
 let TOKEN_DECIMALS_CACHE: { [chainId: number]: { [address: string]: number } } = {
   [SupportedChainId.MAINNET]: {
@@ -62,12 +63,12 @@ export abstract class Fetcher {
     const constantProduct = await factory.getPair(tokenA.address, tokenB.address, 0)
 
     // get native pairs
-    const nativeTokenAConstantProduct = await factory.getPair(tokenA.address, WETH9[chainId], 0)
-    const nativeTokenAStable = await factory.getPair(tokenA.address, WETH9[chainId], 1)
-    const nativeTokenBConstantProduct = await factory.getPair(tokenA.address, WETH9[chainId], 0)
-    const nativeTokenBStable = await factory.getPair(tokenA.address, WETH9[chainId], 1)
+    const nativeTokenAConstantProduct = await factory.getPair(tokenA.address, WETH9[chainId].address, 0)
+    const nativeTokenAStable = await factory.getPair(tokenA.address, WETH9[chainId].address, 1)
+    const nativeTokenBConstantProduct = await factory.getPair(tokenB.address, WETH9[chainId].address, 0)
+    const nativeTokenBStable = await factory.getPair(tokenB.address, WETH9[chainId].address, 1)
 
-    return [stable, constantProduct, nativeTokenAConstantProduct, nativeTokenAStable, nativeTokenBConstantProduct, nativeTokenBStable].filter(address => address != null)
+    return [stable, constantProduct, nativeTokenAConstantProduct, nativeTokenAStable, nativeTokenBConstantProduct, nativeTokenBStable].filter(address => address != AddressZero)
   }
 
   /**

--- a/src/fetcher.ts
+++ b/src/fetcher.ts
@@ -68,7 +68,7 @@ export abstract class Fetcher {
     const nativeTokenBConstantProduct = await factory.getPair(tokenB.address, WETH9[chainId].address, 0)
     const nativeTokenBStable = await factory.getPair(tokenB.address, WETH9[chainId].address, 1)
 
-    return [
+    const relevantPairs = [
       stable,
       constantProduct,
       nativeTokenAConstantProduct,
@@ -76,6 +76,8 @@ export abstract class Fetcher {
       nativeTokenBConstantProduct,
       nativeTokenBStable
     ].filter(address => address != AddressZero)
+
+    return [... new Set(relevantPairs)] // de-duplicate repeated addresses
   }
 
   /**

--- a/src/fetcher.ts
+++ b/src/fetcher.ts
@@ -8,7 +8,7 @@ import { FACTORY_ADDRESS } from './constants'
 import GenericFactory from './abis/GenericFactory.json'
 import ReservoirPair from './abis/ReservoirPair.json'
 import JSBI from 'jsbi'
-import {AddressZero} from "@ethersproject/constants";
+import { AddressZero } from '@ethersproject/constants'
 
 let TOKEN_DECIMALS_CACHE: { [chainId: number]: { [address: string]: number } } = {
   [SupportedChainId.MAINNET]: {

--- a/src/fetcher.ts
+++ b/src/fetcher.ts
@@ -113,6 +113,7 @@ export abstract class Fetcher {
    * Fetches information about a pair and constructs a pair from the given two tokens.
    * @param tokenA first token
    * @param tokenB second token
+   * @param curveId 0 for ConstantProduct, 1 for Stable
    * @param provider the provider to use to fetch the data
    */
   public static async fetchPairData(

--- a/src/fetcher.ts
+++ b/src/fetcher.ts
@@ -56,6 +56,8 @@ export abstract class Fetcher {
     tokenB: Token,
     provider = getDefaultProvider(getNetwork(chainId))
   ): Promise<Pair[]> {
+    invariant(tokenA.chainId == tokenB.chainId, 'CHAIN_ID')
+    invariant(tokenA != tokenB, 'SAME_TOKEN')
     const factory = new Contract(FACTORY_ADDRESS, GenericFactory.abi, provider)
 
     // get the pairs for the two curves

--- a/src/fetcher.ts
+++ b/src/fetcher.ts
@@ -1,7 +1,7 @@
 import { Contract } from '@ethersproject/contracts'
 import { getNetwork } from '@ethersproject/networks'
 import { getDefaultProvider } from '@ethersproject/providers'
-import {SupportedChainId, Token, CurrencyAmount, WETH9} from '@reservoir-labs/sdk-core'
+import { SupportedChainId, Token, CurrencyAmount, WETH9 } from '@reservoir-labs/sdk-core'
 import { Pair } from './entities/pair'
 import invariant from 'tiny-invariant'
 import { FACTORY_ADDRESS } from './constants'
@@ -67,7 +67,14 @@ export abstract class Fetcher {
     const nativeTokenBConstantProduct = await factory.getPair(tokenA.address, WETH9[chainId], 0)
     const nativeTokenBStable = await factory.getPair(tokenA.address, WETH9[chainId], 1)
 
-    return [stable, constantProduct, nativeTokenAConstantProduct, nativeTokenAStable, nativeTokenBConstantProduct, nativeTokenBStable].filter(address => address != null)
+    return [
+      stable,
+      constantProduct,
+      nativeTokenAConstantProduct,
+      nativeTokenAStable,
+      nativeTokenBConstantProduct,
+      nativeTokenBStable
+    ].filter(address => address != null)
   }
 
   /**

--- a/src/fetcher.ts
+++ b/src/fetcher.ts
@@ -44,8 +44,30 @@ export abstract class Fetcher {
     return await new Contract(FACTORY_ADDRESS, GenericFactory.abi, provider).allPairs()
   }
 
-  public static async fetchRelevantPairs(): Promise<Pair[]> {
-    return []
+  // returns the pairs that should be considered in the routing of trades
+  // only returns pairs that have been instantiated already
+  // does not return pairs that do not exist yet
+  public static async fetchRelevantPairs(
+    chainId: SupportedChainId,
+    tokenA: Token,
+    tokenB: Token,
+    provider = getDefaultProvider(getNetwork(chainId))
+  ): Promise<Pair[]> {
+
+    const factory = new Contract(FACTORY_ADDRESS, GenericFactory.abi, provider)
+
+    // get the pairs for the two curves
+    const stable = await factory.getPair(tokenA.address, tokenB.address, 1)
+    const constantProduct = await factory.getPair(tokenA.address, tokenB.address, 0)
+
+    // get native pairs
+    const nativeTokenAConstantProduct = await factory.getPair(tokenA.address, ??, 0)
+    const nativeTokenAStable = await factory.getPair(tokenA.address, ??, 1)
+
+    const nativeTokenBConstantProduct = await factory.getPair(tokenA.address, ??, 0)
+    const nativeTokenBStable = await factory.getPair(tokenA.address, ??, 1)
+
+    return [stable, constantProduct, nativeTokenAConstantProduct, nativeTokenAStable, nativeTokenBConstantProduct, nativeTokenBStable].filter(address => address != null)
   }
 
   /**

--- a/src/fetcher.ts
+++ b/src/fetcher.ts
@@ -47,13 +47,14 @@ export abstract class Fetcher {
   // returns the pairs that should be considered in the routing of trades
   // only returns pairs that have been instantiated already
   // does not return pairs that do not exist yet
+  // currently it returns the tokenA-tokenB pair for all curves, as well as
+  // pairs that are routed through the native asset as that probably will have the most liquidity
   public static async fetchRelevantPairs(
     chainId: SupportedChainId,
     tokenA: Token,
     tokenB: Token,
     provider = getDefaultProvider(getNetwork(chainId))
   ): Promise<Pair[]> {
-
     const factory = new Contract(FACTORY_ADDRESS, GenericFactory.abi, provider)
 
     // get the pairs for the two curves
@@ -63,7 +64,6 @@ export abstract class Fetcher {
     // get native pairs
     const nativeTokenAConstantProduct = await factory.getPair(tokenA.address, ??, 0)
     const nativeTokenAStable = await factory.getPair(tokenA.address, ??, 1)
-
     const nativeTokenBConstantProduct = await factory.getPair(tokenA.address, ??, 0)
     const nativeTokenBStable = await factory.getPair(tokenA.address, ??, 1)
 

--- a/src/router.ts
+++ b/src/router.ts
@@ -99,6 +99,8 @@ export abstract class Router {
     switch (trade.tradeType) {
       case TradeType.EXACT_INPUT:
         if (etherIn) {
+          // TODO: refactor these code using methodName
+          // If etherIn or out we need to use multicall to unwrap them
           methodName = useFeeOnTransfer ? 'swapExactETHForTokensSupportingFeeOnTransferTokens' : 'swapExactETHForTokens'
           // (uint amountOutMin, address[] calldata path, address to, uint deadline)
           args = [amountOut, path, to, deadline]
@@ -120,6 +122,7 @@ export abstract class Router {
       case TradeType.EXACT_OUTPUT:
         invariant(!useFeeOnTransfer, 'EXACT_OUT_FOT')
         if (etherIn) {
+          // TODO: refactor these code using methodName
           methodName = 'swapETHForExactTokens'
           // (uint amountOut, address[] calldata path, address to, uint deadline)
           args = [amountOut, path, to, deadline]


### PR DESCRIPTION
## Notes for my own reference

Which files did Kenneth touch when he tweaked the single / multihop thing???
  - so he did not change the SDK, but instead changed the interface code to make `maxHops` 1 or 2, and `maxNumResults`
    - he did call Trade::bestTradeExactIn/Out
    - the commit where he disabled the multihop
      - https://github.com/vexchange/vexchange-interface/commits/dev?after=b7c66b0a0a170ddabe6c996e1434751ef8b393f9+34&branch=dev&qualified_name=refs%2Fheads%2Fdev
      - he set maxHops to 1 and maxNumResults to 1
  - commit where they re-enabled multihop but force everything through the VET pair
      - https://github.com/vexchange/vexchange-interface/commit/9eb0f11ad141b94b655125fed18e73916fe179ca

    - allowedPairs in the frontend interface calculates the common pairs similar to what we do for `getRelevantPairs`  

The `Router` class only executes the route/trade that has been pre-computed

--- 

Questions: 
1. how does UniV3 do the `bestExactTradeIn/Out` 
