### PR TITLE
fix: `decimals` `BigInt` conversion problem

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@reservoir-labs/sdk",
   "license": "MIT",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "description": "🛠 An SDK for building applications on top of Reservoir",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/entities/route.ts
+++ b/src/entities/route.ts
@@ -59,9 +59,9 @@ export class Route<TInput extends Currency, TOutput extends Currency> {
     } else {
       if (token.equals(pair.token0)) {
         const stableSpotPrice = calculateStableSpotPrice(
-            pair.reserve0.toExact(),
-            pair.reserve1.toExact(),
-            pair.amplificationCoefficient!.toString()
+          pair.reserve0.toExact(),
+          pair.reserve1.toExact(),
+          pair.amplificationCoefficient!.toString()
         )
         // we express the price as a fraction with the numerator at index 0 and denominator at index 1
         // to feed into the `Price` constructor
@@ -69,9 +69,9 @@ export class Route<TInput extends Currency, TOutput extends Currency> {
         price = new Price(pair.reserve0.currency, pair.reserve1.currency, frac[1].toString(), frac[0].toString())
       } else {
         const stableSpotPrice = calculateStableSpotPrice(
-            pair.reserve1.toExact(),
-            pair.reserve0.toExact(),
-            pair.amplificationCoefficient!.toString()
+          pair.reserve1.toExact(),
+          pair.reserve0.toExact(),
+          pair.amplificationCoefficient!.toString()
         )
         const frac = stableSpotPrice.toFraction()
         price = new Price(pair.reserve1.currency, pair.reserve0.currency, frac[1].toString(), frac[0].toString())

--- a/src/entities/route.ts
+++ b/src/entities/route.ts
@@ -3,7 +3,6 @@ import { Currency, Price, Token } from '@reservoir-labs/sdk-core'
 
 import { Pair } from './pair'
 import { calculateStableSpotPrice } from '../lib/stableMath'
-import { decimal } from '../lib/numbers'
 
 export class Route<TInput extends Currency, TOutput extends Currency> {
   public readonly pairs: Pair[]

--- a/src/entities/route.ts
+++ b/src/entities/route.ts
@@ -57,33 +57,25 @@ export class Route<TInput extends Currency, TOutput extends Currency> {
         ? new Price(pair.reserve0.currency, pair.reserve1.currency, pair.reserve0.quotient, pair.reserve1.quotient)
         : new Price(pair.reserve1.currency, pair.reserve0.currency, pair.reserve1.quotient, pair.reserve0.quotient)
     } else {
-      price = token.equals(pair.token0)
-        ? new Price(
-            pair.reserve0.currency,
-            pair.reserve1.currency,
-            1e18,
-            calculateStableSpotPrice(
-              pair.reserve0.toExact(),
-              pair.reserve1.toExact(),
-              pair.amplificationCoefficient!.toString()
-            )
-              .mul(decimal(10).pow(18))
-              .toDP(0)
-              .toString()
-          )
-        : new Price(
-            pair.reserve1.currency,
-            pair.reserve0.currency,
-            1e18,
-            calculateStableSpotPrice(
-              pair.reserve1.toExact(),
-              pair.reserve0.toExact(),
-              pair.amplificationCoefficient!.toString()
-            )
-              .mul(decimal(10).pow(18))
-              .toDP(0)
-              .toString()
-          )
+      if (token.equals(pair.token0)) {
+        const stableSpotPrice = calculateStableSpotPrice(
+            pair.reserve0.toExact(),
+            pair.reserve1.toExact(),
+            pair.amplificationCoefficient!.toString()
+        )
+        // we express the price as a fraction with the numerator at index 0 and denominator at index 1
+        // to feed into the `Price` constructor
+        const frac = stableSpotPrice.toFraction()
+        price = new Price(pair.reserve0.currency, pair.reserve1.currency, frac[1].toString(), frac[0].toString())
+      } else {
+        const stableSpotPrice = calculateStableSpotPrice(
+            pair.reserve1.toExact(),
+            pair.reserve0.toExact(),
+            pair.amplificationCoefficient!.toString()
+        )
+        const frac = stableSpotPrice.toFraction()
+        price = new Price(pair.reserve1.currency, pair.reserve0.currency, frac[1].toString(), frac[0].toString())
+      }
     }
     return price
   }

--- a/src/lib/numbers.ts
+++ b/src/lib/numbers.ts
@@ -3,6 +3,11 @@ import { BigNumber } from '@ethersproject/bignumber'
 
 const SCALING_FACTOR = 1e18
 
+// 78 is the length of max uint256
+// this is to ensure that all the decimals outputs in string are given in raw form instead of in exponential form
+// which can caues problems for BigInt
+Decimal.set({ toExpPos: 78 })
+
 export type BigNumberish = string | number | BigNumber
 
 export const decimal = (x: BigNumberish | Decimal): Decimal => new Decimal(x.toString())

--- a/src/lib/numbers.ts
+++ b/src/lib/numbers.ts
@@ -51,65 +51,6 @@ export const min = (a: BigNumberish, b: BigNumberish): BigNumber => {
   return a.lt(b) ? a : b
 }
 
-export const bnSum = (bnArr: BigNumberish[]): BigNumber => {
-  return bn(bnArr.reduce((prev, curr) => bn(prev).add(bn(curr)), 0))
-}
-
-export const arrayAdd = (arrA: BigNumberish[], arrB: BigNumberish[]): BigNumber[] =>
-  arrA.map((a, i) => bn(a).add(bn(arrB[i])))
-
-export const arrayFpMul = (arrA: BigNumberish[], arrB: BigNumberish[]): BigNumber[] =>
-  arrA.map((a, i) => fpMul(a, arrB[i]))
-
-export const arraySub = (arrA: BigNumberish[], arrB: BigNumberish[]): BigNumber[] =>
-  arrA.map((a, i) => bn(a).sub(bn(arrB[i])))
-
-export const fpMul = (a: BigNumberish, b: BigNumberish): BigNumber =>
-  bn(a)
-    .mul(b)
-    .div(FP_SCALING_FACTOR)
-
-export const fpDiv = (a: BigNumberish, b: BigNumberish): BigNumber =>
-  bn(a)
-    .mul(FP_SCALING_FACTOR)
-    .div(b)
-
-export const divCeil = (x: BigNumber, y: BigNumber): BigNumber =>
-  // ceil(x/y) == (x + y - 1) / y
-  x
-    .add(y)
-    .sub(1)
-    .div(y)
-
-const FP_SCALING_FACTOR = bn(SCALING_FACTOR)
-export const FP_ZERO = fp(0)
-export const FP_ONE = fp(1)
-export const FP_100_PCT = fp(1)
-
-export function printGas(gas: number | BigNumber): string {
-  if (typeof gas !== 'number') {
-    gas = gas.toNumber()
-  }
-
-  return `${(gas / 1000).toFixed(1)}k`
-}
-
-export function scaleUp(n: BigNumber, scalingFactor: BigNumber): BigNumber {
-  if (scalingFactor == bn(1)) {
-    return n
-  }
-
-  return n.mul(scalingFactor)
-}
-
-export function scaleDown(n: BigNumber, scalingFactor: BigNumber): BigNumber {
-  if (scalingFactor == bn(1)) {
-    return n
-  }
-
-  return n.div(scalingFactor)
-}
-
 function parseScientific(num: string): string {
   // If the number is not in scientific notation return it as it is
   if (!/\d+\.?\d*e[+-]*\d+/i.test(num)) return num

--- a/src/lib/stableMath.test.ts
+++ b/src/lib/stableMath.test.ts
@@ -1,8 +1,8 @@
 import { calculateStableSpotPrice } from './stableMath'
-import {DEFAULT_AMPLIFICATION_COEFFICIENT_PRECISE, /*ONE_ETHER*/} from '../constants'
+import { DEFAULT_AMPLIFICATION_COEFFICIENT_PRECISE /*ONE_ETHER*/ } from '../constants'
 import { Decimal } from 'decimal.js'
-import {decimal} from "./numbers";
-import {Price, Token} from "@reservoir-labs/sdk-core";
+import { decimal } from './numbers'
+import { Price, Token } from '@reservoir-labs/sdk-core'
 
 describe('stableMath', () => {
   const token0 = new Token(1, '0x0000000000000000000000000000000000000001', 18, 't0')
@@ -30,11 +30,14 @@ describe('stableMath', () => {
     console.log(result)
 
     const frac = result.toFraction()
-    console.log("0", frac[0].toString())
+    console.log('0', frac[0].toString())
     console.log(frac[1].toString())
 
-    const resultString = result.mul(decimal(10).pow(18)).trunc().valueOf()
-    console.log("res", resultString)
+    const resultString = result
+      .mul(decimal(10).pow(18))
+      .trunc()
+      .valueOf()
+    console.log('res', resultString)
 
     // this is one way to fix the problem
     new Price(token0, token1, frac[1].toString(), frac[0].toString())

--- a/src/lib/stableMath.test.ts
+++ b/src/lib/stableMath.test.ts
@@ -13,7 +13,7 @@ describe('stableMath', () => {
 
     const result = calculateStableSpotPrice(scaledReserve0, scaledReserve1, amplificationCoefficient.toString())
 
-    expect(result.toString()).toEqual('1.2987033193626902185')
+    expect(result.toString()).toEqual('1.2987033193626896932')
   })
 
   it('output of calculateStableSpotPrice feeds nicely into Price', () => {
@@ -27,6 +27,6 @@ describe('stableMath', () => {
     // this is one way to fix the problem
     const price = new Price(token0, token1, frac[1].toString(), frac[0].toString())
 
-    expect(price.toFixed(10)).toEqual('5051125.1559835483')
+    expect(price.toFixed(10)).toEqual('5051125.1559835484')
   })
 })

--- a/src/lib/stableMath.test.ts
+++ b/src/lib/stableMath.test.ts
@@ -1,7 +1,5 @@
 import { calculateStableSpotPrice } from './stableMath'
 import { DEFAULT_AMPLIFICATION_COEFFICIENT_PRECISE /*ONE_ETHER*/ } from '../constants'
-import { Decimal } from 'decimal.js'
-import { decimal } from './numbers'
 import { Price, Token } from '@reservoir-labs/sdk-core'
 
 describe('stableMath', () => {
@@ -18,31 +16,17 @@ describe('stableMath', () => {
     expect(result.toString()).toEqual('1.2987033193626902185')
   })
 
-  it('asd', () => {
+  it('output of calculateStableSpotPrice feeds nicely into Price', () => {
     const scaledReserve0 = '150006'
     const scaledReserve1 = '0.014163206786684748'
     const amplificationCoefficient = DEFAULT_AMPLIFICATION_COEFFICIENT_PRECISE
 
-    Decimal.set({ toExpPos: 50 })
-
     const result = calculateStableSpotPrice(scaledReserve1, scaledReserve0, amplificationCoefficient.toString())
-
-    console.log(result)
-
     const frac = result.toFraction()
-    console.log('0', frac[0].toString())
-    console.log(frac[1].toString())
-
-    const resultString = result
-      .mul(decimal(10).pow(18))
-      .trunc()
-      .valueOf()
-    console.log('res', resultString)
 
     // this is one way to fix the problem
-    new Price(token0, token1, frac[1].toString(), frac[0].toString())
+    const price = new Price(token0, token1, frac[1].toString(), frac[0].toString())
 
-    // another way to fix it is to set the expPos to a very large number
-    // Decimal.set({ toExpPos: 30 })
+    expect(price.toFixed(10)).toEqual('5051125.1559835483')
   })
 })

--- a/src/lib/stableMath.test.ts
+++ b/src/lib/stableMath.test.ts
@@ -1,7 +1,13 @@
 import { calculateStableSpotPrice } from './stableMath'
-import { DEFAULT_AMPLIFICATION_COEFFICIENT_PRECISE } from '../constants'
+import {DEFAULT_AMPLIFICATION_COEFFICIENT_PRECISE, /*ONE_ETHER*/} from '../constants'
+import { Decimal } from 'decimal.js'
+import {decimal} from "./numbers";
+import {Price, Token} from "@reservoir-labs/sdk-core";
 
 describe('stableMath', () => {
+  const token0 = new Token(1, '0x0000000000000000000000000000000000000001', 18, 't0')
+  const token1 = new Token(1, '0x0000000000000000000000000000000000000001', 18, 't0')
+
   it('calculateStableSpotPrice', () => {
     const scaledReserve0 = '103219283019283019283'
     const scaledReserve1 = '5003210341820391823093'
@@ -10,5 +16,30 @@ describe('stableMath', () => {
     const result = calculateStableSpotPrice(scaledReserve0, scaledReserve1, amplificationCoefficient.toString())
 
     expect(result.toString()).toEqual('1.2987033193626902185')
+  })
+
+  it('asd', () => {
+    const scaledReserve0 = '150006'
+    const scaledReserve1 = '0.014163206786684748'
+    const amplificationCoefficient = DEFAULT_AMPLIFICATION_COEFFICIENT_PRECISE
+
+    Decimal.set({ toExpPos: 50 })
+
+    const result = calculateStableSpotPrice(scaledReserve1, scaledReserve0, amplificationCoefficient.toString())
+
+    console.log(result)
+
+    const frac = result.toFraction()
+    console.log("0", frac[0].toString())
+    console.log(frac[1].toString())
+
+    const resultString = result.mul(decimal(10).pow(18)).trunc().valueOf()
+    console.log("res", resultString)
+
+    // this is one way to fix the problem
+    new Price(token0, token1, frac[1].toString(), frac[0].toString())
+
+    // another way to fix it is to set the expPos to a very large number
+    // Decimal.set({ toExpPos: 30 })
   })
 })

--- a/src/lib/stableMath.ts
+++ b/src/lib/stableMath.ts
@@ -135,6 +135,7 @@ function _getTokenBalanceGivenInvariantAndAllOtherBalances(
 }
 
 // calculates the spot price of token1 in token0
+// reserves are in decimal form. E.g. 500.1 USDC would be 500.1, not 500100000
 export function calculateStableSpotPrice(
   scaledReserve0: BigNumberish,
   scaledReserve1: BigNumberish,


### PR DESCRIPTION
this is so solve the problem where `decimals.js` was returning a string such as `2.9199006463644886923e+21` to be converted to a BigInt, which obviously `BigInt` would complain.

In my research, I've determined two solutions to this problem:
1. use the fraction representation of the price returned by `calculateStableSpotPrice`
   - this works nicely as the `Price` object accepts fraction as an input
   - technically this is not super necessary, but having this saves the computation of having to scale the price by 1e18 and then truncating the decimals
3. fix the upper threshold such that beyond that the decimals library will return the number in exponential notation
   - `Decimal.set({ toExpPos: 50 })` setting it to something like this would also solve the problem. The number would have to be more than 50 digits to be returned as exponential
   - I set it to 78 as that's the length of `uint256` 


Both solutions are implemented to make sure that this problem would not occur again